### PR TITLE
Fix docker after moving to `CheckerNetwork`

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -40,8 +40,8 @@ jobs:
           context: .
           push: true
           tags: |
-            ghcr.io/filecoin-station/core
-            ghcr.io/filecoin-station/core:${{ steps.package-version.outputs.current-version }}
+            ghcr.io/CheckerNetwork/core
+            ghcr.io/CheckerNetwork/core:${{ steps.package-version.outputs.current-version }}
           platforms: linux/amd64,linux/arm64
-          cache-from: type=registry,ref=ghcr.io/filecoin-station/core
+          cache-from: type=registry,ref=ghcr.io/CheckerNetwork/core
           cache-to: type=inline

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:20-slim
-LABEL org.opencontainers.image.source=https://github.com/filecoin-station/core
+LABEL org.opencontainers.image.source=https://github.com/CheckerNetwork/core
 USER node
 WORKDIR /usr/src/app
 COPY . .

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ $ docker run \
 	--detach \
 	--env FIL_WALLET_ADDRESS=0x000000000000000000000000000000000000dEaD \
         -v ./state:/home/node/.local/state/
-	ghcr.io/filecoin-station/core
+	ghcr.io/CheckerNetwork/core
 ```
 
 ## Manual Deployment (Ubuntu)


### PR DESCRIPTION
This prevents new users from installing from the old URL. Independent of this, I will notify existing users of the new URL.