### PR TITLE
updated the base node image in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-slim
+FROM node:22.13.1-slim
 LABEL org.opencontainers.image.source=https://github.com/filecoin-station/core
 USER node
 WORKDIR /usr/src/app


### PR DESCRIPTION
Partially Fixes https://github.com/CheckerNetwork/roadmap/issues/210

Updated the Node.js base image from node:20-slim to node:22-slim as requested in issue 210 of the roadmap repository.