### PR TITLE
zinnia: fix reporting AbortErrors to Sentry

### DIFF
--- a/lib/zinnia.js
+++ b/lib/zinnia.js
@@ -319,8 +319,12 @@ export async function run ({
     ])
     console.error('Zinnia main loop ended')
   } catch (err) {
-    console.error('Zinnia main loop errored', err)
-    maybeReportErrorToSentry(err)
+    if (err.name === 'AbortError') {
+      console.error('Zinnia main loop aborted')
+    } else {
+      console.error('Zinnia main loop errored', err)
+      maybeReportErrorToSentry(err)
+    }
   } finally {
     controller.abort()
   }

--- a/lib/zinnia.js
+++ b/lib/zinnia.js
@@ -280,6 +280,11 @@ export async function run ({
           type: 'error',
           message: `${capitalize(module)} has been inactive for 5 minutes, restarting...`
         })
+
+        const err = new Error('Module inactive for 5 minutes')
+        Object.assign(err, { module })
+        maybeReportErrorToSentry(err)
+
         controller.abort()
       }, 5 * 60 * 1000)
     }


### PR DESCRIPTION
Fixes https://space-meridian.sentry.io/issues/5857510005/?query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&sort=freq&statsPeriod=14d&stream_index=1 and more.

Before this change, an abort error will always be reported to Sentry. Situations that trigger an abort:

- Module has been inactive (I have added error handling specifically for this here)
- Any other error happened (this is already being reported to Sentry, no need to report the resulting abort error)
- Restarting Zinnia after updating source files (not an error)

Looking at Sentry, and especially the view of all issues sorted by number of events, this is the biggest offender that is still happening.